### PR TITLE
Update publish_session_geometry.py

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -281,7 +281,7 @@ class BlenderSessionGeometryPublishPlugin(HookBaseClass):
                 context,
                 filepath=publish_path,
                 selected=False,
-                renderable_only=True,
+                visible_objects_only=True,
                 uvs=True,
                 face_sets=True,
                 start=start_frame,


### PR DESCRIPTION
removed renderable_only flag was removed ref# cb1601ddf37f on developer.blender.org.  Added visible_objects_only to restore similar functionality.