### PR TITLE
Compatability Dialog Functionalized and Moved to Pre_app_init() and c…

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -309,7 +309,9 @@ def _find_scene_animation_range():
         start, end = 1, 1
     else:
         start, end = keys[0], keys[-1]
-
+        start = int(start)
+        end = int(end)
+        
     return start, end
 
 


### PR DESCRIPTION
Due to an order of operations issue it seems like the dialog box for displaying a message about compatibility was trying to call qt before it was available.   To fix this I functionalized all the compatibility code and then moved the execution of this code from init_engine to pre_app_init().  Also in this commit I fixed an issue with the publish_session_geo hook in which I forced the start and end frame retrieved from the bpy module as strings into int's.